### PR TITLE
Potential fix for code scanning alert no. 2: Call to obsolete method

### DIFF
--- a/WebServiceStudio/Wsdl.cs
+++ b/WebServiceStudio/Wsdl.cs
@@ -546,7 +546,6 @@ namespace WebServiceStudio
 
         private void GenerateAssembly()
         {
-            ICodeCompiler compiler = codeProvider.CreateCompiler();
             string location = "";
             if ((WsdlProperties.ProxyBaseType != null) && (WsdlProperties.ProxyBaseType.Length > 0))
             {
@@ -560,7 +559,7 @@ namespace WebServiceStudio
             var options = new CompilerParameters(assemblyNames);
             options.WarningLevel = 0;
             options.GenerateInMemory = false;
-            CompilerResults results = compiler.CompileAssemblyFromSource(options, proxyCode);
+            CompilerResults results = codeProvider.CompileAssemblyFromSource(options, proxyCode);
             if (results.Errors.HasErrors)
             {
                 foreach (CompilerError error in results.Errors)


### PR DESCRIPTION
Potential fix for [https://github.com/Ken-Tucker/WebServiceStudio/security/code-scanning/2](https://github.com/Ken-Tucker/WebServiceStudio/security/code-scanning/2)

Replace usage of the obsolete `CreateCompiler()`/`ICodeCompiler` pattern with direct invocation of `CodeDomProvider.CompileAssemblyFromSource(...)`.

Best minimal fix (no behavior change):
- In `WebServiceStudio/Wsdl.cs`, method `GenerateAssembly()`:
  - Remove `ICodeCompiler compiler = codeProvider.CreateCompiler();`
  - Replace `compiler.CompileAssemblyFromSource(options, proxyCode)` with `codeProvider.CompileAssemblyFromSource(options, proxyCode)`

No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
